### PR TITLE
Feature/multi return warning

### DIFF
--- a/markdown_refdocs/main.py
+++ b/markdown_refdocs/main.py
@@ -126,7 +126,9 @@ class ModuleAnalyzer(ast.NodeVisitor):
                 'hidden': False,
             }
         )
-        doc = parse_google_docstring(ast.get_docstring(node), self.hide_undoc_args)
+        doc = parse_google_docstring(
+            ast.get_docstring(node), self.hide_undoc_args, self.get_qualified_name(node, node.name)
+        )
         result.update(
             {d: doc[d] for d in doc if d not in ['parameters', 'raises', 'returns', 'attributes']}
         )
@@ -179,13 +181,19 @@ class ModuleAnalyzer(ast.NodeVisitor):
             and not result['is_class_method']
         )
 
-        doc = parse_google_docstring(ast.get_docstring(node), self.hide_undoc_args)
+        doc = parse_google_docstring(
+            ast.get_docstring(node), self.hide_undoc_args, self.get_qualified_name(node, node.name)
+        )
         result.update({d: doc[d] for d in doc if d != 'parameters'})
 
         class_doc = ParsedDocstring({})
 
         if class_parent and node.name == '__init__':
-            class_doc = parse_google_docstring(ast.get_docstring(node.parent), self.hide_undoc_args)
+            class_doc = parse_google_docstring(
+                ast.get_docstring(node.parent),
+                self.hide_undoc_args,
+                self.get_qualified_name(node, node.name),
+            )
 
         if self.hide_private and node.name.startswith('_') and node.name != '__init__':
             result['hidden'] = True

--- a/markdown_refdocs/parsers.py
+++ b/markdown_refdocs/parsers.py
@@ -14,7 +14,9 @@ def left_align_block(block: str) -> str:
     return content
 
 
-def parse_google_docstring(docstring: str, hide_undoc: bool = True) -> ParsedDocstring:
+def parse_google_docstring(
+    docstring: str, hide_undoc: bool = True, function_name=''
+) -> ParsedDocstring:
     """
     parses a google-style docsting into a dictionary of the various sections
     """
@@ -96,8 +98,12 @@ def parse_google_docstring(docstring: str, hide_undoc: bool = True) -> ParsedDoc
     for i, line in enumerate(content['returns']):
         _, arg_type, arg_desc = re.match(r'^(([^:]+):)?\s*(.*)$', line).groups()
         if result['returns']:
-            raise AttributeError('unable to parse docstring with multiple returns')
-        result['returns'] = ParsedReturn({'type': arg_type, 'description': arg_desc})
+            result['returns']['description'] += ' ' + line
+        else:
+            print(
+                f'warning: {function_name} multiple return lines, being appended to the description'
+            )
+            result['returns'] = ParsedReturn({'type': arg_type, 'description': arg_desc})
 
     result['description'] = '\n'.join(content['desc'])
     result['note'] = '\n'.join(content['note'])

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ except Exception as err:
 
 setup(
     name='markdown_refdocs',
-    version='1.1.1',
+    version='1.1.2',
     long_description=long_description,
     long_description_content_type='text/markdown',
     packages=find_packages(),

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -11,3 +11,22 @@ Args:
         )
         assert len(result['parameters']) == 1
         assert result['parameters'][0]['type'] == 'List[Dict]'
+
+    def test_add_extra_returns_to_description(self):
+        result = parse_google_docstring(
+            """
+Returns:
+    response: the response
+    data (list, dict or None): The ids and type of resource object(s) in this relationship.
+    meta (dict): meta information about the response
+        total (int): total records available in the relationship
+        count (int): total records returned in the response
+        limit (int): the page size
+        offset (int): starting point of the page
+    links (dict): paging links to prev and next page, plus link to current request
+"""
+        )
+        assert (
+            result['returns']
+            == 'the response data (list, dict or None): The ids and type of resource object(s) in this relationship. meta (dict): meta information about the response total (int): total records available in the relationship count (int): total records returned in the response limit (int): the page size offset (int): starting point of the page links (dict): paging links to prev and next page, plus link to current request'
+        )

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -27,6 +27,6 @@ Returns:
 """
         )
         assert (
-            result['returns']
+            result['returns']['description']
             == 'the response data (list, dict or None): The ids and type of resource object(s) in this relationship. meta (dict): meta information about the response total (int): total records available in the relationship count (int): total records returned in the response limit (int): the page size offset (int): starting point of the page links (dict): paging links to prev and next page, plus link to current request'
         )


### PR DESCRIPTION
BugFixes
- log warning on multiple returns in docstring instead of throwing error