### PR TITLE
fix: support both singular and plural examples

### DIFF
--- a/markdown_refdocs/markdown.py
+++ b/markdown_refdocs/markdown.py
@@ -53,6 +53,14 @@ def argument_md(
 
 
 def admonitions_to_markdown(parsed: Dict[str, List[str]]) -> str:
+    """
+    Generate markdown-style admonitions
+
+    Examples:
+        admonitions_to_markdown({'note': ['make a note of this']})
+
+        admonitions_to_markdown({'warning': ['this is important']})
+    """
     md: List[str] = []
     for admonition in ADMONITIONS:
         if parsed.get(admonition, []):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -46,8 +46,11 @@ Returns:
         tuple: The result of splitting the input string.
     Examples:
         prefix_split('A12345') == ('A', '12345')
+
         prefix_split('HTMCP_1') == ('HTMCP_', '1')
+
         prefix_split('ABC') == ('ABC', None)
+
         prefix_split('12345') == (None, '12345')
         prefix_split('A123B') == (None, None)"""
         )
@@ -58,3 +61,5 @@ If the input string is only letters, return a tuple of ({letters}, None).
 If the input string is only numbers, return a tuple of (None, {numbers}).
 Otherwise return a tuple of Nones."""
         assert result['description'] == expected
+        print(result.keys())
+        assert len(result['examples']) == 4

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -61,5 +61,4 @@ If the input string is only letters, return a tuple of ({letters}, None).
 If the input string is only numbers, return a tuple of (None, {numbers}).
 Otherwise return a tuple of Nones."""
         assert result['description'] == expected
-        print(result.keys())
         assert len(result['examples']) == 4


### PR DESCRIPTION
BugFixes
- #15 Support "Examples" as well as "Example" sections. Split "Examples" by blank lines